### PR TITLE
Fix an error when feeding the lib and not the apex

### DIFF
--- a/bt-patcher.sh
+++ b/bt-patcher.sh
@@ -59,6 +59,9 @@ patched_hex=(
 if ! [ -e "in" ]; then
 	mkdir in
 fi
+if ! [ -e "tmp" ]; then
+	mkdir tmp
+fi
 if ! [ -e "lib_stock" ]; then
 	mkdir lib_stock
 fi


### PR DESCRIPTION
I used to extract the lib from apex manually and it's failing because the folder /tmp isn't created.

![Capture d'écran 2025-02-28 000227](https://github.com/user-attachments/assets/9596d9aa-54e9-475e-b1a8-a26cba798595)
